### PR TITLE
Add job link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -60,12 +60,12 @@ custom_css = ["css/custom.css"]
     btnURL="#portfolio"
 
     # call to action
-    #[params.cta]
-    #enable = true
-    #title = "Great Design & Incredible Features"
+    [params.cta]
+    enable = true
+    title = "We Are Hiring!"
     #content = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Officiis tenetur odio impedit incidunt? Omnis accusantium ea reiciendis, fugit commodi nostrum."
-    #btnURL = "#"
-    #btnText = "Start a project with us"
+    btnURL = "https://uwhires.admin.washington.edu/eng/candidates/default.cfm?szCategory=jobprofile&szOrderID=204529&szCandidateID=0&szReturnToSearch=1"
+    btnText = "University of Washington Job Listing"
 
     # counter
     #[params.counter]

--- a/config.toml
+++ b/config.toml
@@ -62,10 +62,10 @@ custom_css = ["css/custom.css"]
     # call to action
     [params.cta]
     enable = true
-    title = "We Are Hiring!"
+    title = "Current Job Openings"
     #content = "Lorem ipsum dolor sit amet consectetur adipisicing elit. Officiis tenetur odio impedit incidunt? Omnis accusantium ea reiciendis, fugit commodi nostrum."
     btnURL = "https://uwhires.admin.washington.edu/eng/candidates/default.cfm?szCategory=jobprofile&szOrderID=204529&szCandidateID=0&szReturnToSearch=1"
-    btnText = "University of Washington Job Listing"
+    btnText = "Software Engineer - 2 Openings"
 
     # counter
     #[params.counter]

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -104,6 +104,10 @@ a,
   border-left: 2px solid #afbac4;
 }
 
+.btn-main {
+  color: #fff;
+}
+
 .member-meta span {
   color: #57cbcc;
 }

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -104,7 +104,7 @@ a,
   border-left: 2px solid #afbac4;
 }
 
-.btn-main {
+.call-to-action .btn-main {
   color: #fff;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -171,6 +171,20 @@
 
 
     
+<!-- Start Call To Action -->
+<section class="call-to-action section-sm bg-1 overly" style='background-image: url("/")'>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12 text-center">
+                <h2>We Are Hiring!</h2> 
+               
+                <a href="https://uwhires.admin.washington.edu/eng/candidates/default.cfm?szCategory=jobprofile&amp;szOrderID=204529&amp;szCandidateID=0&amp;szReturnToSearch=1" class="btn btn-main"> University of Washington Job Listing </a>
+            </div>
+        </div>
+    </div>
+</section>
+<!-- Start Services Section -->
+
 
     
         

--- a/public/index.html
+++ b/public/index.html
@@ -176,9 +176,9 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12 text-center">
-                <h2>We Are Hiring!</h2> 
+                <h2>Current Job Openings</h2> 
                
-                <a href="https://uwhires.admin.washington.edu/eng/candidates/default.cfm?szCategory=jobprofile&amp;szOrderID=204529&amp;szCandidateID=0&amp;szReturnToSearch=1" class="btn btn-main"> University of Washington Job Listing </a>
+                <a href="https://uwhires.admin.washington.edu/eng/candidates/default.cfm?szCategory=jobprofile&amp;szOrderID=204529&amp;szCandidateID=0&amp;szReturnToSearch=1" class="btn btn-main"> Software Engineer - 2 Openings </a>
             </div>
         </div>
     </div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -104,6 +104,10 @@ a,
   border-left: 2px solid #afbac4;
 }
 
+.btn-main {
+  color: #fff;
+}
+
 .member-meta span {
   color: #57cbcc;
 }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -104,7 +104,7 @@ a,
   border-left: 2px solid #afbac4;
 }
 
-.btn-main {
+.call-to-action .btn-main {
   color: #fff;
 }
 


### PR DESCRIPTION
Marie asked me to add the job link to the CSSAT site. The site is kind of confusing to customize, so I decided to uncomment some code that adds a block under the About Us section that includes a link to the job listing.

Original Screenie
*NOTE: updated one below
<img width="1550" alt="Screen Shot 2022-06-03 at 2 57 54 PM" src="https://user-images.githubusercontent.com/13345485/171959539-22df36bf-1ecb-41e2-8408-49a1e8d5ab4d.png">
